### PR TITLE
switch to maintained elm-base64

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",
-        "lattenwald/elm-base64": "1.0.0 <= v < 2.0.0"
+        "truqu/elm-base64": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
I was unable to get elm-jwt to compile on elm 0.18 without this change, due to missing dependency NoRedInk/elm-lazy-list.