### PR TITLE
switched base64 implementations

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,11 +11,11 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "danfishgold/base64-bytes": "1.1.0 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/http": "2.0.0 <= v < 3.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
-        "elm/time": "1.0.0 <= v < 2.0.0",
-        "truqu/elm-base64": "2.0.4 <= v < 3.0.0"
+        "elm/time": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.0 <= v < 2.0.0"

--- a/src/Jwt.elm
+++ b/src/Jwt.elm
@@ -131,13 +131,13 @@ getTokenParts token =
         [ Ok header, Ok body, _ ] ->
             let
                 header_ =
-                    Base64.decode header
-                        |> Result.mapError (\_ -> TokenHeaderError)
+                    Base64.toString header
+                        |> Result.fromMaybe TokenHeaderError
                         |> Result.andThen (verifyJson (\_ -> TokenHeaderError))
 
                 body_ =
-                    Base64.decode body
-                        |> Result.mapError TokenProcessingError
+                    Base64.toString body
+                        |> Result.fromMaybe (TokenProcessingError "Invalid UTF-16")
                         |> Result.andThen (verifyJson TokenDecodeError)
             in
             Result.map2 (\a b -> ( a, b )) header_ body_


### PR DESCRIPTION
Switched the Base64 library used to `danfishgold/base64-bytes` for performance and future compatibility reasons.
closes #26